### PR TITLE
Create an abstract class for the classifiers

### DIFF
--- a/App/src/main/java/com/sarangi/app/App.java
+++ b/App/src/main/java/com/sarangi/app/App.java
@@ -51,17 +51,17 @@ public class App
                 String testFilename = "src/resources/song/songFeatures/test.txt";
 
                 
-               //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/features.txt"),new String("src/resources/song/Mood_training"));
-               //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/test.txt"),new String("src/resources/song/Mood_testing"));
+               FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/features.txt"),new String("src/resources/song/Mood_training"));
+               FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/test.txt"),new String("src/resources/song/Mood_testing"));
 
                 System.out.println("Running SVM...");
-                SVMRunner svmRunner= new SVMRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
-                //SVMRunner svmRunner= new SVMRunner(new String[]{"high_arousal","low_arousal"});
+                //SVMRunner svmRunner= new SVMRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
+                SVMRunner svmRunner= new SVMRunner(new String[]{"high_arousal","low_arousal"});
                 svmRunner.run(trainingFilename,testFilename);
 
                 System.out.println("Running ANN...");
-                ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
-                //ANNRunner annRunner= new ANNRunner(new String[]{"high_arousal","low_arousal"});
+                //ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
+                ANNRunner annRunner= new ANNRunner(new String[]{"high_arousal","low_arousal"});
                 annRunner.run(trainingFilename,testFilename);
 
         }

--- a/App/src/main/java/com/sarangi/app/App.java
+++ b/App/src/main/java/com/sarangi/app/App.java
@@ -15,6 +15,7 @@ import com.sarangi.learningmodel.ann.SarangiANN;
 import com.sarangi.learningmodel.ann.ANNRunner;
 import com.sarangi.learningmodel.svm.SarangiSVM;
 import com.sarangi.learningmodel.svm.SVMRunner;
+import com.sarangi.learningmodel.*;
 
 /**
  * A main class for interfacing all the other sub-classes.
@@ -51,18 +52,18 @@ public class App
                 String testFilename = "src/resources/song/songFeatures/test.txt";
 
                 
-               FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/features.txt"),new String("src/resources/song/Mood_training"));
-               FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/test.txt"),new String("src/resources/song/Mood_testing"));
+               //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/features.txt"),new String("src/resources/song/Mood_training"));
+               //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/test.txt"),new String("src/resources/song/Mood_testing"));
 
                 System.out.println("Running SVM...");
-                //SVMRunner svmRunner= new SVMRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
-                SVMRunner svmRunner= new SVMRunner(new String[]{"high_arousal","low_arousal"});
-                svmRunner.run(trainingFilename,testFilename);
+                SVMRunner svmRunner= new SVMRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
+                //SVMRunner svmRunner= new SVMRunner(new String[]{"high_arousal","low_arousal"});
+                svmRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
 
                 System.out.println("Running ANN...");
-                //ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
-                ANNRunner annRunner= new ANNRunner(new String[]{"high_arousal","low_arousal"});
-                annRunner.run(trainingFilename,testFilename);
+                ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
+                //ANNRunner annRunner= new ANNRunner(new String[]{"high_arousal","low_arousal"});
+                annRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
 
         }
 }

--- a/App/src/main/java/com/sarangi/learningmodel/Classifier.java
+++ b/App/src/main/java/com/sarangi/learningmodel/Classifier.java
@@ -1,0 +1,29 @@
+/**
+ * @(#) Classifier.java 2.0     July 29, 2016
+ *
+ * Bijay Gurung
+ *
+ * Insitute of Engineering
+ */
+
+package com.sarangi.learningmodel;
+
+import com.sarangi.structures.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.*;
+
+/**
+ * Interface for all Sarangi Classifiers.
+ *
+ *
+ * @author Bijay Gurung
+ */
+
+public interface Classifier {
+
+        public int predict(Song song);
+        public Result test(List<Song> testSongs);
+
+}

--- a/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
@@ -1,0 +1,37 @@
+/**
+ * @(#) ClassifierRunner.java 2.0     July 31, 2016
+ *
+ * Bijay Gurung
+ *
+ * Insitute of Engineering
+ */
+
+package com.sarangi.learningmodel; 
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
+import com.sarangi.structures.*;
+import com.sarangi.json.*;
+import com.sarangi.learningmodel.*;
+
+/**
+ * Abstract Class representing the runners for different classifiers.
+ *
+ * @author Bijay Gurung
+ */
+
+
+public abstract class ClassifierRunner {
+
+        protected String[] labels;
+
+        public ClassifierRunner(String[] labels) {
+        
+                this.labels = labels;
+        }
+
+        public abstract void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException;
+
+}

--- a/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
@@ -32,6 +32,6 @@ public abstract class ClassifierRunner {
                 this.labels = labels;
         }
 
-        public abstract void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException;
+        public abstract void run(String trainingFilename, String testFilename, DatasetUtil.FeatureType featureType) throws FileNotFoundException, IOException;
 
 }

--- a/App/src/main/java/com/sarangi/learningmodel/SarangiClassifier.java
+++ b/App/src/main/java/com/sarangi/learningmodel/SarangiClassifier.java
@@ -1,5 +1,5 @@
 /**
- * @(#) SarangiClassifier.java 2.0     July 29, 2016
+ * @(#) SarangiClassifier.java 2.0     July 31, 2016
  *
  * Bijay Gurung
  *
@@ -21,9 +21,109 @@ import java.util.logging.*;
  * @author Bijay Gurung
  */
 
-public interface SarangiClassifier {
+public abstract class SarangiClassifier implements Classifier {
 
-        public int predict(Song song);
-        public Result test(List<Song> testSongs);
+        /**
+         * The labels.
+         *
+         */
+        public String[] labels;
+
+        /**
+         * The Feature Type.
+         *
+         */
+        public DatasetUtil.FeatureType featureType;
+
+        /**
+         * The training dataset.
+         *
+         */
+
+        public LearningDataset trainingSet; 
+
+        /**
+         * Three argument constructor.
+         *
+         * @param trainingSongs The songs to be used for training
+         * @param labels The string labels
+         * @param featureType The type of feature to be used
+         *
+         */
+        public SarangiClassifier(List<Song> trainingSongs, String[] labels, DatasetUtil.FeatureType featureType) {
+
+                this.labels = labels;
+                this.featureType = featureType;
+
+                this.train(trainingSongs);
+
+        }
+
+        /**
+         * Train the model using the given songs.
+         * The specific model to be used is determined by the child class.
+         *
+         * @param trainingSongs The songs to be used for training.
+         *
+         */
+
+        public abstract void train(List<Song> trainingSongs);
+
+        /**
+         * Predict the label for the given song.
+         * How the prediction is done is dependent on the specific model being used.
+         *
+         * @param song The Song object whose label is to be predicted.
+         *
+         * @return The label index.
+         */
+
+        public abstract int predict(Song song);
+
+        /**
+         * Tests the model on the given songs.
+         *
+         * @param testSongs The test Songs.
+         * @return The result of the test.
+         */
+        public Result test(List<Song> testSongs) {
+                   int correct = 0;
+                    double[] labelAccuracy = new double[this.labels.length];
+                    double[] labelCount = new double[this.labels.length];
+                    int[][] confusionMatrix = new int[this.labels.length][this.labels.length];
+                    double accuracy = 0.0;
+
+                try{
+
+                    for (Song song: testSongs) {
+
+                            int labelIndex = DatasetUtil.getIndexOfLabel(song.getSongName(),this.labels);
+
+                            labelCount[labelIndex-1]++;
+                            int predictedLabel = this.predict(song);
+
+                            confusionMatrix[labelIndex-1][predictedLabel-1]++;
+
+                            if (predictedLabel == labelIndex){
+                                    labelAccuracy[labelIndex-1]++;
+                                    correct++;
+                            }
+                    }
+
+                    int numOfSongs = testSongs.size();
+
+                    accuracy = (100.0*correct/numOfSongs);
+
+                    for (int i=0; i<labelAccuracy.length; i++) {
+                            labelAccuracy[i] = (100.0*labelAccuracy[i]/labelCount[i]);
+                    }
+
+
+                }catch (Exception ex){
+                        ex.printStackTrace();
+                }
+                    return new Result(accuracy,this.labels,labelAccuracy,confusionMatrix);
+  
+        }
 
 }

--- a/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
@@ -27,19 +27,16 @@ import java.lang.Math.*;
 
 /**
  * Class to Run SarangiSVM class.
- * TODO This and SVMRunner could have an abstract parent class
  *
  * @author Bijay Gurung
  */
 
 
-public class ANNRunner {
-
-        private String[] labels;
+public class ANNRunner extends ClassifierRunner {
 
         public ANNRunner(String[] labels) {
         
-                this.labels = labels;
+                super(labels);
         }
 
         public void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException  {

--- a/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
@@ -39,7 +39,7 @@ public class ANNRunner extends ClassifierRunner {
                 super(labels);
         }
 
-        public void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException  {
+        public void run(String trainingFilename, String testFilename, DatasetUtil.FeatureType featureType) throws FileNotFoundException, IOException  {
 
                 SongHandler trainingSongHandler = new SongHandler(trainingFilename);
                 List<Song> trainingSongs = trainingSongHandler.loadSongs();
@@ -47,7 +47,7 @@ public class ANNRunner extends ClassifierRunner {
                 SongHandler testSongHandler = new SongHandler(testFilename);
                 List<Song> testSongs = testSongHandler.loadSongs();
 
-                SarangiANN ann = new SarangiANN(trainingSongs,this.labels,DatasetUtil.FeatureType.SARANGI_PITCH);
+                SarangiANN ann = new SarangiANN(trainingSongs,this.labels,featureType);
                 
                 Result result = ann.test(testSongs);
 

--- a/App/src/main/java/com/sarangi/learningmodel/ann/SarangiANN.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ann/SarangiANN.java
@@ -28,7 +28,7 @@ import java.lang.Math.*;
  * @author Mehang Rai
  * */
 
-public class SarangiANN implements SarangiClassifier {
+public class SarangiANN extends SarangiClassifier {
 
         /* FIELDS **************************************************/
 
@@ -37,31 +37,6 @@ public class SarangiANN implements SarangiClassifier {
          *
          */
         public NeuralNetwork ann;
-
-        /**
-         * The labels.
-         *
-         */
-        public String[] labels;
-
-        /**
-         * The Feature Type.
-         *
-         */
-        public DatasetUtil.FeatureType featureType;
-
-        /**
-         * The training dataset.
-         *
-         */
-
-        public LearningDataset trainingSet; 
-
-        /**
-         * The testing dataset.
-         *
-         */
-        public LearningDataset testSet; 
 
 
         /**
@@ -74,16 +49,22 @@ public class SarangiANN implements SarangiClassifier {
          */
         public SarangiANN(List<Song>trainingSongs, String[] labels, DatasetUtil.FeatureType featureType) {
 
-                this.labels = labels;
-                this.featureType = featureType;
+                super(trainingSongs,labels,featureType);
 
+        }
+        
+        /**
+         * Train the model in a Neural Network.
+         *
+         * @param trainingSongs The songs to be used for training.
+         *
+         */
+
+        public void train(List<Song> trainingSongs) {
                 this.trainingSet = DatasetUtil.getSongwiseDataset(trainingSongs, labels, featureType);
-
-                // Train ANN
 
                 ann = new NeuralNetwork(NeuralNetwork.ErrorFunction.LEAST_MEAN_SQUARES,NeuralNetwork.ActivationFunction.LOGISTIC_SIGMOID,30,15,15);
                 ann.learn(trainingSet.dataset,trainingSet.labelIndices);
-
         }
 
         /**
@@ -102,50 +83,4 @@ public class SarangiANN implements SarangiClassifier {
                 return ann.predict(songDataset.dataset[0]);
         }
 
-        /**
-         * Tests the model on the given songs.
-         * TODO This could be put into an abstract class 
-         *
-         * @param testSongs The test Songs.
-         * @return The result of the test.
-         */
-        public Result test(List<Song> testSongs) {
-                    int correct = 0;
-                    double[] labelAccuracy = new double[this.labels.length];
-                    double[] labelCount = new double[this.labels.length];
-                    int[][] confusionMatrix = new int[this.labels.length][this.labels.length];
-                    double accuracy = 0.0;
-
-                try{
-
-                    for (Song song: testSongs) {
-
-                            int labelIndex = DatasetUtil.getIndexOfLabel(song.getSongName(),this.labels);
-
-                            labelCount[labelIndex-1]++;
-                            int predictedLabel = this.predict(song);
-
-                            confusionMatrix[labelIndex-1][predictedLabel-1]++;
-
-                            if (predictedLabel == labelIndex){
-                                    labelAccuracy[labelIndex-1]++;
-                                    correct++;
-                            }
-                    }
-
-                    int numOfSongs = testSongs.size();
-
-                    accuracy = (100.0*correct/numOfSongs);
-
-                    for (int i=0; i<labelAccuracy.length; i++) {
-                            labelAccuracy[i] = (100.0*labelAccuracy[i]/labelCount[i]);
-                    }
-
-
-                }catch (Exception ex){
-                        ex.printStackTrace();
-                }
-                    return new Result(accuracy,this.labels,labelAccuracy,confusionMatrix);
-        }
-
-}
+ }

--- a/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
@@ -34,13 +34,10 @@ import java.lang.Math.*;
  */
 
 
-public class SVMRunner {
-
-        private String[] labels;
+public class SVMRunner extends ClassifierRunner {
 
         public SVMRunner(String[] labels) {
-        
-                this.labels = labels;
+                super(labels); 
         }
 
         public void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException  {

--- a/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
@@ -40,7 +40,7 @@ public class SVMRunner extends ClassifierRunner {
                 super(labels); 
         }
 
-        public void run(String trainingFilename, String testFilename) throws FileNotFoundException, IOException  {
+        public void run(String trainingFilename, String testFilename, DatasetUtil.FeatureType featureType) throws FileNotFoundException, IOException  {
 
                 SongHandler trainingSongHandler = new SongHandler(trainingFilename);
                 List<Song> trainingSongs = trainingSongHandler.loadSongs();
@@ -48,7 +48,7 @@ public class SVMRunner extends ClassifierRunner {
                 SongHandler testSongHandler = new SongHandler(testFilename);
                 List<Song> testSongs = testSongHandler.loadSongs();
 
-                SarangiSVM svm = new SarangiSVM(trainingSongs,this.labels,DatasetUtil.FeatureType.SARANGI_MFCC);
+                SarangiSVM svm = new SarangiSVM(trainingSongs,this.labels, featureType);
                 
                 Result result = svm.test(testSongs);
 


### PR DESCRIPTION
Created an abstract class `ClassifierRunner` that is to be extended by all _"runners"_.

Also, created an abstract class `SarangiClassifier` which implements `Classifier` which is an interface for all classifiers. 

So, right now `SarangiANN` and `SarangiSVM` extends `SarangiClassifier`. 

The idea is that methods like `test()` are pretty much the same for all classifiers. Here it's calling `predict()` which is different for each individual classifier. 

```
public Result test(List<Song> testSongs) {
             ........
             int predictedLabel = this.predict(song);
             ..........
       return new Result(accuracy,this.labels,labelAccuracy,confusionMatrix);
}

```
