### PR TITLE
Add K-fold validation with random partition

### DIFF
--- a/App/src/main/java/com/sarangi/app/App.java
+++ b/App/src/main/java/com/sarangi/app/App.java
@@ -55,15 +55,17 @@ public class App
                //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/features.txt"),new String("src/resources/song/Mood_training"));
                //FeatureExtractor.extractFeature(new String("src/resources/song/songFeatures/test.txt"),new String("src/resources/song/Mood_testing"));
 
-                System.out.println("Running SVM...");
+                //System.out.println("Running SVM...");
                 SVMRunner svmRunner= new SVMRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
                 //SVMRunner svmRunner= new SVMRunner(new String[]{"high_arousal","low_arousal"});
-                svmRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
+                //svmRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
+                svmRunner.runCrossValidation(trainingFilename,DatasetUtil.FeatureType.SARANGI_MFCC,10);
 
-                System.out.println("Running ANN...");
-                ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
+                //System.out.println("Running ANN...");
+                //ANNRunner annRunner= new ANNRunner(new String[]{"classical","hiphop","jazz","pop","rock"});
                 //ANNRunner annRunner= new ANNRunner(new String[]{"high_arousal","low_arousal"});
-                annRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
+                //annRunner.run(trainingFilename,testFilename, DatasetUtil.FeatureType.SARANGI_MFCC);
+                //annRunner.runCrossValidation(trainingFilename, DatasetUtil.FeatureType.SARANGI_MFCC,5);
 
         }
 }

--- a/App/src/main/java/com/sarangi/learningmodel/Result.java
+++ b/App/src/main/java/com/sarangi/learningmodel/Result.java
@@ -99,6 +99,15 @@ public class Result {
                 }
         }
 
+        /**
+         * Get the accuracy.
+         *
+         *
+         */
+        public double getAccuracy() {
+                return accuracy;
+        }
+
 
 
 }

--- a/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ann/ANNRunner.java
@@ -53,4 +53,47 @@ public class ANNRunner extends ClassifierRunner {
                 result.printData();
         }
 
+        /**
+         * Run K-fold Cross Validation.
+         *
+         * TODO This and the one in SVMRunner could be abstracted out.
+         *
+         * @param filename The file holding the feature data.
+         * @param featureType The type of feature to be used for testing.
+         * @param k The number of partitions to create.
+         *
+         */
+
+        public void runCrossValidation(String filename, DatasetUtil.FeatureType featureType, int k) throws FileNotFoundException, IOException  {
+
+                SongHandler songHandler = new SongHandler(filename);
+                List<Song> songs = songHandler.loadSongs();
+
+                int partitionSize = songs.size()/k;
+                Collections.shuffle(songs);
+
+                double overallAvgAccuracy = 0.0;
+
+                for (int i=0; i < k; i++) {
+                        int lowerIndex = i*partitionSize;
+                        int upperIndex = (i+1)*partitionSize;
+
+                        List<Song> trainingSongs = new ArrayList<Song>(songs);
+                        List<Song> testSongs = new ArrayList<Song>(trainingSongs.subList(lowerIndex,upperIndex));
+
+                        trainingSongs.removeAll(testSongs);
+
+                        SarangiANN ann = new SarangiANN(trainingSongs,this.labels,featureType);
+                
+                        Result result = ann.test(testSongs);
+
+                        result.printData();
+
+                        overallAvgAccuracy += result.getAccuracy();
+
+                }
+
+                System.out.format("K-fold accuracy: %.2f%%", overallAvgAccuracy/k);
+        }
+
 }

--- a/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/svm/SVMRunner.java
@@ -56,4 +56,45 @@ public class SVMRunner extends ClassifierRunner {
 
         }
 
+        /**
+         * Run K-fold Cross Validation.
+         *
+         * @param filename The file holding the feature data.
+         * @param featureType The type of feature to be used for testing.
+         * @param k The number of partitions to create.
+         *
+         */
+
+        public void runCrossValidation(String filename, DatasetUtil.FeatureType featureType, int k) throws FileNotFoundException, IOException  {
+
+                SongHandler songHandler = new SongHandler(filename);
+                List<Song> songs = songHandler.loadSongs();
+
+                int partitionSize = songs.size()/k;
+                Collections.shuffle(songs);
+
+                double overallAvgAccuracy = 0.0;
+
+                for (int i=0; i < k; i++) {
+                        int lowerIndex = i*partitionSize;
+                        int upperIndex = (i+1)*partitionSize;
+
+                        List<Song> trainingSongs = new ArrayList<Song>(songs);
+                        List<Song> testSongs = new ArrayList<Song>(trainingSongs.subList(lowerIndex,upperIndex));
+
+                        trainingSongs.removeAll(testSongs);
+
+                        SarangiSVM svm = new SarangiSVM(trainingSongs,this.labels,featureType);
+                
+                        Result result = svm.test(testSongs);
+
+                        result.printData();
+
+                        overallAvgAccuracy += result.getAccuracy();
+
+                }
+
+                System.out.format("K-fold accuracy: %.2f%%", overallAvgAccuracy/k);
+
+        }
 }


### PR DESCRIPTION
Currently, the K-fold validation is being done in the following way:

- First, get all songs. 
- Randomly shuffle the songs.
- Divide the songs into k partitions.
- Use one partition for testing and the others for training. So, this is repeated for k times.
- Get the average accuracy.

**TODO:**
Distribute the genre equally among the partitions. 
Abstract away the `runCrossValidation()` method.