### PR TITLE
Add Precision, Recall and FMeasure

### DIFF
--- a/App/src/main/java/com/sarangi/app/App.java
+++ b/App/src/main/java/com/sarangi/app/App.java
@@ -115,7 +115,7 @@ public class App
 
                 if (test.kfoldFile != null) {
                     ClassifierRunner runner = new ClassifierRunner(labelsArray.get(test.labelIndex));
-                    runner.runCrossValidation(test.kfoldFile, FeatureType.SARANGI_ALL,10,ClassifierType.fromString(test.classifierType),false);
+                    runner.runCrossValidation(test.kfoldFile, FeatureType.SARANGI_ALL,10,ClassifierType.fromString(test.classifierType),true);
                 }
 
             }else if(jc.getParsedCommand().equals("classify")) {

--- a/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
+++ b/App/src/main/java/com/sarangi/learningmodel/ClassifierRunner.java
@@ -151,6 +151,9 @@ public class ClassifierRunner {
                 }
 
                 double overallAvgAccuracy = 0.0;
+                double overallAvgFMeasure = 0.0;
+                double overallAvgPrecision = 0.0;
+                double overallAvgRecall = 0.0;
 
                 ClassifierFactory factory = new ClassifierFactory();
 
@@ -169,11 +172,18 @@ public class ClassifierRunner {
 
                         result.printData();
 
-                        overallAvgAccuracy += result.getAccuracy();
+                        overallAvgAccuracy += result.accuracy;
+                        overallAvgFMeasure += result.fMeasure;
+                        overallAvgPrecision += result.precision;
+                        overallAvgRecall += result.recall;
 
                 }
 
+                System.out.format("\n\nResults with %d-fold cross validation\n\n",k);
                 System.out.format("[====> K-fold accuracy: %.2f%% <====]\n\n", overallAvgAccuracy/k);
+                System.out.format("[====> K-fold Precision: %.2f <====]\n\n", overallAvgPrecision/k);
+                System.out.format("[====> K-fold Recall: %.2f <====]\n\n", overallAvgRecall/k);
+                System.out.format("[====> K-fold FMeasure: %.2f <====]\n\n", overallAvgFMeasure/k);
 
         }
 }

--- a/App/src/main/java/com/sarangi/learningmodel/Result.java
+++ b/App/src/main/java/com/sarangi/learningmodel/Result.java
@@ -15,6 +15,11 @@ import java.io.*;
 import java.util.*;
 import java.util.logging.*;
 
+import smile.validation.FMeasure;
+import smile.validation.Precision;
+import smile.validation.Recall;
+import smile.validation.Sensitivity;
+
 /**
  * Class for holding result of a classification.
  *
@@ -31,6 +36,24 @@ public class Result {
      *
      */
     public double accuracy;
+
+    /**
+     * The FMeasure of the result.
+     *
+     */
+    public double fMeasure;
+
+    /**
+     * The Precision of the result.
+     *
+     */
+    public double precision;
+
+    /**
+     * The Recall of the result.
+     *
+     */
+    public double recall;
 
     /**
      * The labels for the dataset.
@@ -50,6 +73,18 @@ public class Result {
      */
     public int[][] confusionMatrix;
 
+    /**
+     * The actual labels of the data.
+     *
+     */
+    public int[] actualLabels;
+
+    /** 
+     * The labels predicted by the model.
+     *
+     */
+    public int[] predictedLabels;
+
     /* CONSTRUCTORS *******************************************/
 
     /**
@@ -62,16 +97,25 @@ public class Result {
     /**
      * Initialization in the constructor.
      *
+     * @param actualLabels The actual labels for the data.
+     * @param predictedLabels The predicted labels.
      * @param accuracy The overall accuracy.
      * @param labels The strings representing the labels. 
      * @param labelAccuracy The accuracy for each label.
+     * @param confusionMatrix The confusion matrix
      *
      */
-    public Result(double accuracy, String[] labels, double[] labelAccuracy, int[][] confusionMatrix) {
+    public Result(int[] actualLabels, int[] predictedLabels, double accuracy, String[] labels, double[] labelAccuracy, int[][] confusionMatrix) {
+        this.actualLabels = actualLabels;
+        this.predictedLabels = predictedLabels;
         this.accuracy = accuracy;
         this.labels = labels;
         this.labelAccuracy = labelAccuracy;
         this.confusionMatrix = confusionMatrix;
+
+        this.fMeasure = (new FMeasure()).measure(actualLabels,predictedLabels);
+        this.precision = (new Precision()).measure(actualLabels,predictedLabels);
+        this.recall = (new Recall()).measure(actualLabels,predictedLabels);
     }
 
     /**
@@ -79,7 +123,11 @@ public class Result {
      *
      */
     public void printData() {
-        System.out.format("Overall Accuracy: %.2f%%\n",this.accuracy);
+
+        System.out.format("\nOverall Accuracy: %.2f%%\n",this.accuracy);
+        System.out.format("Precision: %.2f\n",this.precision);
+        System.out.format("Recall: %.2f\n",this.recall);
+        System.out.format("FMeasure: %.2f\n",this.fMeasure);
 
         if (labels.length != labelAccuracy.length) {
             System.out.println("Error: Number of labels and accuracy count don't match");
@@ -92,19 +140,10 @@ public class Result {
 
         for (int i=0; i<confusionMatrix.length; i++ ){
             for (int j=0; j<confusionMatrix[i].length; j++) {
-                System.out.format("%d ",confusionMatrix[i][j]);
+                System.out.format("%2d ",confusionMatrix[i][j]);
             }
             System.out.println();
         }
-    }
-
-    /**
-     * Get the accuracy.
-     *
-     *
-     */
-    public double getAccuracy() {
-        return accuracy;
     }
 
 }

--- a/App/src/main/java/com/sarangi/learningmodel/SarangiClassifier.java
+++ b/App/src/main/java/com/sarangi/learningmodel/SarangiClassifier.java
@@ -112,8 +112,12 @@ public abstract class SarangiClassifier implements Classifier, Serializable {
         double[] labelCount = new double[this.labels.length];
         int[][] confusionMatrix = new int[this.labels.length][this.labels.length];
         double accuracy = 0.0;
+        int[] predictedLabels = new int[testSongs.size()];
+        int[] actualLabels = new int[testSongs.size()];
 
         try{
+
+            int index = 0;
 
             for (Song song: testSongs) {
 
@@ -128,6 +132,11 @@ public abstract class SarangiClassifier implements Classifier, Serializable {
                     labelAccuracy[labelIndex-1]++;
                     correct++;
                 }
+
+                predictedLabels[index] = predictedLabel;
+                actualLabels[index] = labelIndex;
+
+                index++;
             }
 
             int numOfSongs = testSongs.size();
@@ -143,7 +152,7 @@ public abstract class SarangiClassifier implements Classifier, Serializable {
 
             ex.printStackTrace();
         }
-        return new Result(accuracy,this.labels,labelAccuracy,confusionMatrix);
+        return new Result(actualLabels,predictedLabels,accuracy,this.labels,labelAccuracy,confusionMatrix);
 
     }
 

--- a/App/src/main/java/com/sarangi/learningmodel/svm/SarangiSVM.java
+++ b/App/src/main/java/com/sarangi/learningmodel/svm/SarangiSVM.java
@@ -73,7 +73,10 @@ public class SarangiSVM extends SarangiClassifier {
         this.trainingSet = DatasetUtil.getSongwiseDataset(trainingSongs, labels, featureType);
 
         svm = new SVM(new GaussianKernel(SarangiSVM.SIGMA), 2.0d, Math.max(trainingSet.labelIndices)+1, SVM.Multiclass.ONE_VS_ONE);
-        svm.learn(trainingSet.dataset,trainingSet.labelIndices);
+        int epoch = 10;
+        for (int i=0; i<epoch; i++) {
+            svm.learn(trainingSet.dataset,trainingSet.labelIndices);
+        }
         svm.finish();
     }
 


### PR DESCRIPTION
Added [Precision](https://en.wikipedia.org/wiki/Information_retrieval#Precision), [Recall](https://en.wikipedia.org/wiki/Information_retrieval#Recall) and FMeasure ([F1 score](https://en.wikipedia.org/wiki/Information_retrieval#F-score_.2F_F-measure)) to `Result`. 

Also, add extra epoch to `learn()` on `SarangiSVM`.